### PR TITLE
Feature/player controller

### DIFF
--- a/Dawn.uproject
+++ b/Dawn.uproject
@@ -21,6 +21,15 @@
 			"TargetAllowList": [
 				"Editor"
 			]
+		},
+		{
+			"Name": "Bridge",
+			"Enabled": true,
+			"SupportedTargetPlatforms": [
+				"Win64",
+				"Mac",
+				"Linux"
+			]
 		}
 	]
 }

--- a/Source/Dawn/Character/DCCharacterBase.cpp
+++ b/Source/Dawn/Character/DCCharacterBase.cpp
@@ -2,6 +2,7 @@
 
 
 #include "Dawn/Character/DCCharacterBase.h"
+#include "Dawn/DCPlayerController.h"
 
 // Sets default values
 ADCCharacterBase::ADCCharacterBase()
@@ -16,12 +17,23 @@ void ADCCharacterBase::BeginPlay()
 {
 	Super::BeginPlay();
 	
+	// Initialize player controller and check it is ok
+	DCPlayerController = Cast<ADCPlayerController>(GetController());
+	DCCHECK(nullptr != DCPlayerController);
+
 }
 
 // Called every frame
 void ADCCharacterBase::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
+
+}
+
+// Called after initializing components
+void ADCCharacterBase::PostInitializeComponents()
+{
+	Super::PostInitializeComponents();
 
 }
 

--- a/Source/Dawn/Character/DCCharacterBase.h
+++ b/Source/Dawn/Character/DCCharacterBase.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
+#include "Dawn/Dawn.h"
 #include "GameFramework/Character.h"
 #include "DCCharacterBase.generated.h"
 
@@ -22,8 +22,15 @@ protected:
 public:	
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
+	// Called after initializing components
+	virtual void PostInitializeComponents() override;
 
 	// Called to bind functionality to input
 	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+
+private:
+	// Player Controller property
+	UPROPERTY()
+	class ADCPlayerController* DCPlayerController;
 
 };

--- a/Source/Dawn/DCGameModeBase.h
+++ b/Source/Dawn/DCGameModeBase.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
+#include "Dawn.h"
 #include "GameFramework/GameModeBase.h"
 #include "DCGameModeBase.generated.h"
 

--- a/Source/Dawn/DCGameStateBase.h
+++ b/Source/Dawn/DCGameStateBase.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
+#include "Dawn.h"
 #include "GameFramework/GameStateBase.h"
 #include "DCGameStateBase.generated.h"
 

--- a/Source/Dawn/DCPlayerController.cpp
+++ b/Source/Dawn/DCPlayerController.cpp
@@ -2,4 +2,30 @@
 
 
 #include "Dawn/DCPlayerController.h"
+#include "Dawn/Character/DCCharacterBase.h"
 
+// Sets default values
+ADCPlayerController::ADCPlayerController()
+{
+
+}
+
+// Called after initializing components
+void ADCPlayerController::PostInitializeComponents()
+{
+	Super::PostInitializeComponents();
+	DCLOG_S(Warning);
+}
+
+// Overridable native function for when this controller is asked to possess a pawn.
+void ADCPlayerController::OnPossess(APawn* aPawn)
+{
+	DCLOG_S(Warning);
+	Super::OnPossess(aPawn);
+}
+
+// Called when the game starts or when spawned
+void ADCPlayerController::BeginPlay()
+{
+	Super::BeginPlay();
+}

--- a/Source/Dawn/DCPlayerController.h
+++ b/Source/Dawn/DCPlayerController.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
+#include "Dawn.h"
 #include "GameFramework/PlayerController.h"
 #include "DCPlayerController.generated.h"
 
@@ -14,4 +14,17 @@ class DAWN_API ADCPlayerController : public APlayerController
 {
 	GENERATED_BODY()
 	
+public:
+	//
+	ADCPlayerController();
+	
+	// Called after initializing components
+	virtual void PostInitializeComponents() override;
+	// Overridable native function for when this controller is asked to possess a pawn.
+	virtual void OnPossess(APawn* aPawn) override;
+	
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
 };

--- a/Source/Dawn/DCPlayerState.h
+++ b/Source/Dawn/DCPlayerState.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
+#include "Dawn.h"
 #include "GameFramework/PlayerState.h"
 #include "DCPlayerState.generated.h"
 

--- a/Source/Dawn/Dawn.cpp
+++ b/Source/Dawn/Dawn.cpp
@@ -3,6 +3,6 @@
 #include "Dawn.h"
 #include "Modules/ModuleManager.h"
 
+DEFINE_LOG_CATEGORY(Dawn);
 IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, Dawn, "Dawn" );
 
-DEFINE_LOG_CATEGORY(Dawn);

--- a/Source/Dawn/Dawn.h
+++ b/Source/Dawn/Dawn.h
@@ -7,5 +7,5 @@
 DECLARE_LOG_CATEGORY_EXTERN(Dawn, Log, All);		// Log category "Dawn"
 #define DCLOG_CALLINFO (FString(__FUNCTION__) + TEXT("(") + FString::FromInt(__LINE__) + TEXT(")"))
 #define DCLOG_S(Verbosity) UE_LOG(Dawn, Verbosity, TEXT("%s"), *DCLOG_CALLINFO)
-#define DCLOG(Verbosity, Format, ...) UE_LOG(Dawn, Verbodity, TEXT("%s %s"), *DCLOG_CALLINFO, *FString::Printf(Format, ##__VA_ARGS__))
+#define DCLOG(Verbosity, Format, ...) UE_LOG(Dawn, Verbosity, TEXT("%s %s"), *DCLOG_CALLINFO, *FString::Printf(Format, ##__VA_ARGS__))
 #define DCCHECK(Expr, ...) { if(!(Expr)) {DCLOG(Error, TEXT("ASSERTION : %s"), TEXT("'"#Expr"'")); return __VA_ARGS__; }}

--- a/Source/Dawn/UI/DCMainHUDWidget.h
+++ b/Source/Dawn/UI/DCMainHUDWidget.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
+#include "Dawn/Dawn.h"
 #include "Blueprint/UserWidget.h"
 #include "DCMainHUDWidget.generated.h"
 


### PR DESCRIPTION
- Dawn.h에 DCLOG 버그(오타) 수정.
- "Dawn.h"의 "CoreMinimal.h"를 "EngineMinimal.h"로 변경 (더 넓은 범위 헤더파일).
- Source의 header 파일들 "CoreMinimal.h"에서 "Dawn.h"로 변경.

> **앞으로 헤더파일 만들 때 logging macro 사용하려면 계속 바꿔줘야 함.**

- Player Controller class에 기본 함수들 선언만 함. 추가 구현 필요.